### PR TITLE
Update naming_conventions.md

### DIFF
--- a/docs/naming_conventions.md
+++ b/docs/naming_conventions.md
@@ -12,7 +12,7 @@ This document outlines the naming conventions used for schemas, tables, views, c
 3. [Column Naming Conventions](#column-naming-conventions)
    - [Surrogate Keys](#surrogate-keys)
    - [Technical Columns](#technical-columns)
-4. [Stored Procedure](#stored-procedure-naming-conventions)
+4. [Stored Procedure](#stored-procedure)
 ---
 
 ## **General Principles**


### PR DESCRIPTION
Clicking on "Stored Procedure" in the Table of Contents was not navigating to the corresponding section in the document. Updated the .md file to correct the anchor link so it now correctly points to the "Stored Procedure" section.

